### PR TITLE
if loop error

### DIFF
--- a/1_lift_vcfs_to_GRCh37.job
+++ b/1_lift_vcfs_to_GRCh37.job
@@ -27,7 +27,7 @@ lift=$HOME/required_tools/lift/LiftMap.py
 cpath=$HOME/required_tools/chainfiles
 
 
-if [ ! -z custom_temp ]; then
+if [ ! -z $custom_temp ]; then
     mkdir -p $custom_temp/$PBS_JOBID
     export TEMP=$custom_temp/$PBS_JOBID
 else


### PR DESCRIPTION
```if [ ! -z custom_temp ]; then``` is absolutely True even the argument not existed and have TEMP unable to make.

should be corrected as  ```if [ ! -z $custom_temp ]; then``` (adding dollar sign.)