### PR TITLE
enable $outsubdir

### DIFF
--- a/6_impute.job
+++ b/6_impute.job
@@ -42,11 +42,11 @@ cd $myoutdir/$outsubdir
 
 
 if [ "$reftype" == "HRC" ]; then
-        echo "Using HRC reference panel, file: /stsi/raqueld/EGA/HRC.r1-1.EGA.GRCh37.chr$mychr.haplotypes.m3vcf.gz"
         myref=/mnt/stsi/stsi0/raqueld/HRC/HRC.r1-1.EGA.GRCh37.chr$mychr.haplotypes.m3vcf.gz
+        echo "Using HRC reference panel, file: ${myref}"
 else
-    	echo "Using 1KG reference, file: /gpfs/group/torkamani/shaun/1000G_VCF/ALL.chr$mychr.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz"
         myref=/mnt/stsi/stsi0/raqueld/1000G/ALL.chr$mychr.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.m3vcf.gz
+        echo "Using 1KG reference panel, file: ${myref}"
 fi
 
 echo "Running Imputation"


### PR DESCRIPTION
`$oursubdir` now is composed of the prefix of myinput ($subdir) and the part of ancestry ($subanc).
```
subdir=$(basename $myinput | sed -e 's/\.lifted.*//g')
subanc=$(basename $myinput | tr '.' '\n' | grep "ancestry")
outsubdir=$subdir/$subanc
```