### PR TITLE
So many good memories!!

### DIFF
--- a/6_impute.job
+++ b/6_impute.job
@@ -17,7 +17,7 @@ echo "myinput $myinput"
 
 module load vcftools
 module load samtools
-module load minimac4
+module load minimac4/1.0.2
 imputationSoftware=minimac4
 
 


### PR DESCRIPTION
Actually, imputed SNP array might need mem=240gb (max value in workq nodes; stsi nodes only have 120gb at most.)
Users might have to manually change those PBS lines for those special cases...