### PR TITLE
Enable multithreaded mode of ADMIXTURE (Hold on...................)

### DIFF
--- a/3_ancestry_analysis.job
+++ b/3_ancestry_analysis.job
@@ -87,7 +87,7 @@ vcfendtime=$(date +%s)
 
 admstarttime=$(date +%s)
 
-	admixture --supervised $inprefix.pruned.intersect1KG.bed 5
+	admixture --supervised $inprefix.pruned.intersect1KG.bed 5 -j16
 
 admendtime=$(date +%s)
 


### PR DESCRIPTION
According to http://software.genetics.ucla.edu/admixture/admixture-manual.pdf (p.11)
```
To split ADMIXTURE’s work among N threads, you may append the flag -jN to your
ADMIXTURE command. The core algorithms will run up to N times as fast, presuming
you have at least N processors.
```

`-j16`, in my case, can speed up 30%. (28228.8 > 20416.2)